### PR TITLE
Add the ability to set folder options per method

### DIFF
--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -105,3 +105,19 @@ describe('Example', () => {
 Compare options are the options that can be set during instantiation of the plugin or per method. If the options has the same key as an option that has been set during the instantiation of the plugin, the method compare option will override the plugin compare option value.
 They can be found <a href="https://github.com/wswebcreation/webdriver-image-comparison/blob/master/docs/OPTIONS.md#compare-options" target="_blank">here</a>.
 The usage can be found above in the plugin and method examples.
+
+## Folder options
+The baseline folder and screenshot folders(actual, diff) are options that can be set during instantiation of the plugin or method. To set the folder options on a particular method, pass in folder options to the methods option object
+```
+const methodOptions = {
+    actualFolder: path.join(process.cwd(), './testActual'),
+    baselineFolder: path.join(process.cwd(), './testBaseline'),
+    diffFolder: path.join(process.cwd(), './testDiff')
+};
+expect(browser.checkFullPageScreen('cehckFullPage', methodOptions)).toEqual(0);
+
+const methodOptions = {
+    actualFolder: path.join(process.cwd(), './testActual')
+};
+const imageData = browser.saveFullPageScreen('saveFullPage', {}, methodOptions);
+```

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -36,6 +36,7 @@ exports.config = {
 ## Method options
 Methods options are the options that can be set per method. If the option has the same key as an options that has been set during the instantiation of the plugin, this method option will override the plugin option value.
 They can be found <a href="https://github.com/wswebcreation/webdriver-image-comparison/blob/master/docs/OPTIONS.md#method-options" target="_blank">here</a>.
+You can now also set folder options, see [here](#folder-options).
 
 An example for all methods can be found below:
 
@@ -108,16 +109,18 @@ The usage can be found above in the plugin and method examples.
 
 ## Folder options
 The baseline folder and screenshot folders(actual, diff) are options that can be set during instantiation of the plugin or method. To set the folder options on a particular method, pass in folder options to the methods option object
-```
+
+```js
 const methodOptions = {
     actualFolder: path.join(process.cwd(), './testActual'),
     baselineFolder: path.join(process.cwd(), './testBaseline'),
     diffFolder: path.join(process.cwd(), './testDiff')
 };
-expect(browser.checkFullPageScreen('cehckFullPage', methodOptions)).toEqual(0);
+
+expect(browser.checkFullPageScreen('checkFullPage', methodOptions)).toEqual(0);
 
 const methodOptions = {
     actualFolder: path.join(process.cwd(), './testActual')
 };
-const imageData = browser.saveFullPageScreen('saveFullPage', {}, methodOptions);
+const imageData = browser.saveFullPageScreen('saveFullPage', methodOptions);
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ export default class WdioImageComparisonService extends BaseClass {
                     screenShot: this.takeScreenshot.bind(browser),
                 },
                 instanceData,
-                folders,
+                getFolders(saveElementOptions, folders),
                 element,
                 tag,
                 {
@@ -50,7 +50,7 @@ export default class WdioImageComparisonService extends BaseClass {
                     screenShot: this.takeScreenshot.bind(browser),
                 },
                 instanceData,
-                folders,
+                getFolders(saveScreenOptions, folders),
                 tag,
                 {
                     wic: defaultOptions,
@@ -68,7 +68,7 @@ export default class WdioImageComparisonService extends BaseClass {
                     screenShot: this.takeScreenshot.bind(browser),
                 },
                 instanceData,
-                folders,
+                getFolders(saveFullPageScreenOptions, folders),
                 tag,
                 {
                     wic: defaultOptions,
@@ -86,7 +86,7 @@ export default class WdioImageComparisonService extends BaseClass {
                     screenShot: this.takeScreenshot.bind(browser),
                 },
                 instanceData,
-                folders,
+                getFolders(checkElementOptions, folders),
                 element,
                 tag,
                 {
@@ -105,7 +105,7 @@ export default class WdioImageComparisonService extends BaseClass {
                     screenShot: this.takeScreenshot.bind(browser),
                 },
                 instanceData,
-                folders,
+                getFolders(checkScreenOptions, folders),
                 tag,
                 {
                     wic: defaultOptions,
@@ -123,7 +123,7 @@ export default class WdioImageComparisonService extends BaseClass {
                     screenShot: this.takeScreenshot.bind(browser),
                 },
                 instanceData,
-                folders,
+                getFolders(checkFullPageOptions, folders),
                 tag,
                 {
                     wic: defaultOptions,
@@ -170,5 +170,25 @@ function getInstanceData(capabilities) {
         name,
         nativeWebScreenshot,
         platformName,
+    };
+}
+
+/**
+ * Get the folders data 
+ *
+ * If folder options are passed in use those values
+ * Otherwise, use the values set during instantiation
+ *
+ * @returns {{
+ *    actualFolder: string,
+ *    baselineFolder: string,
+ *    diffFolder: string
+ *  }}
+ */
+function getFolders(methodOptions, folders) {
+    return {
+      actualFolder: (methodOptions.actualFolder ? methodOptions.actualFolder : folders.actualFolder),
+      baselineFolder: (methodOptions.baselineFolder ? methodOptions.baselineFolder : folders.baselineFolder),
+      diffFolder: (methodOptions.diffFolder ? methodOptions.diffFolder : folders.diffFolder)
     };
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ./lib",
     "test.local.init": "wdio ./tests/configs/wdio.local.init.conf.js",
     "test.local.desktop": "wdio tests/configs/wdio.local.desktop.conf.js",
+    "test.local.autosave": "wdio ./tests/configs/wdio.local.autosave.conf.js",
     "test.saucelabs": "wdio ./tests/configs/wdio.saucelabs.conf.js",
     "watch": "npm run compile -- --watch",
     "release": "np",

--- a/tests/configs/wdio.local.autosave.conf.js
+++ b/tests/configs/wdio.local.autosave.conf.js
@@ -1,0 +1,42 @@
+const { join } = require('path');
+const { config } = require('./wdio.shared.conf');
+const WdioImageComparisonService = require('../../build/');
+
+// ============
+// Capabilities
+// ============
+config.capabilities = [
+    {
+        browserName: 'chrome',
+        specs: [
+            './tests/specs/checkMethodsFolders.spec.js',
+            './tests/specs/saveMethodsFolders.spec.js',
+        ],
+        'goog:chromeOptions': {
+            args: [ 'disable-infobars' ],
+        },
+        'wdio-ics:options': {
+            logName: 'chrome-latest',
+        },
+    },
+];
+
+// ===================
+// Image compare setup
+// ===================
+config.services = [
+    [ WdioImageComparisonService.default, {
+        baselineFolder: join(process.cwd(), './localBaseline/'),
+        debug: true,
+        formatImageName: '{tag}-{logName}-{width}x{height}',
+        screenshotPath: join(process.cwd(), '.tmp/'),
+        savePerInstance: true,
+        blockOutStatusBar: true,
+        blockOutToolBar: true,
+        clearRuntimeFolder: true,
+        autoSaveBaseline: true,
+    } ],
+    'selenium-standalone'
+];
+
+exports.config = config;

--- a/tests/specs/checkMethodsFolders.spec.js
+++ b/tests/specs/checkMethodsFolders.spec.js
@@ -1,0 +1,138 @@
+import fileExists from '../helpers/fileExists';
+const path = require('path');
+
+describe('wdio-image-comparison-service check methods folder options', () => {
+    const logName = browser.logName;
+    const resolution = '1366x768';
+
+    beforeEach(() => {
+        browser.url('');
+        browser.pause(500);
+    });
+
+    // Chrome remembers the last postion when the url is loaded again, this will reset it.
+    afterEach(() => browser.execute('window.scrollTo(0, 0);', []));
+
+    describe('checkFullPageScreen method with folder options', () => {
+        it('should set all folders using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                baselineFolder: path.join(process.cwd(), './testBaseline'),
+                diffFolder: path.join(process.cwd(), './testDiff'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkFullPageScreen('fullPageAllOptions', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch(testOptions.baselineFolder.replace('./',''));
+            expect(results.folders.diff).toMatch(testOptions.diffFolder.replace('./',''));
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+
+        it('should set one folder using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkFullPageScreen('fullPageOneOption', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch('localBaseline');
+            expect(results.folders.diff).toMatch('.tmp');
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+
+        it('should set two folders using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                diffFolder: path.join(process.cwd(), './testDiff'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkScreen('fullPageTwoOptions', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch('localBaseline');
+            expect(results.folders.diff).toMatch(testOptions.diffFolder.replace('./',''));
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+    });
+
+    describe('checkScreen method with folder options', () => {
+        it('should set all folders using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                baselineFolder: path.join(process.cwd(), './testBaseline'),
+                diffFolder: path.join(process.cwd(), './testDiff'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkScreen('screenOptions', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch(testOptions.baselineFolder.replace('./',''));
+            expect(results.folders.diff).toMatch(testOptions.diffFolder.replace('./',''));
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+
+        it('should set one folder using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkFullPageScreen('screenOneOption', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch('localBaseline');
+            expect(results.folders.diff).toMatch('.tmp');
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+
+        it('should set two folders using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                diffFolder: path.join(process.cwd(), './testDiff'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkScreen('screenTwoOptions', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch('localBaseline');
+            expect(results.folders.diff).toMatch(testOptions.diffFolder.replace('./',''));
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+    });
+
+    describe('checkElement method with folder options', () => {
+        it('should set all folders using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                baselineFolder: path.join(process.cwd(), './testBaseline'),
+                diffFolder: path.join(process.cwd(), './testDiff'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkScreen('elementAllOptions', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch(testOptions.baselineFolder.replace('./',''));
+            expect(results.folders.diff).toMatch(testOptions.diffFolder.replace('./',''));
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+
+        it('should set one folder using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkScreen('elementOneOption', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch('localBaseline');
+            expect(results.folders.diff).toMatch('.tmp');
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+
+        it('should set two folders using method options', () => {
+            const testOptions = {
+                actualFolder: path.join(process.cwd(), './testActual'),
+                diffFolder: path.join(process.cwd(), './testDiff'),
+                returnAllCompareData: true
+            };
+            const results = browser.checkScreen('elementTwoOptions', testOptions);
+            expect(results.folders.actual).toMatch(testOptions.actualFolder.replace('./',''));
+            expect(results.folders.baseline).toMatch('localBaseline');
+            expect(results.folders.diff).toMatch(testOptions.diffFolder.replace('./',''));
+            expect(results.misMatchPercentage).toEqual(0);
+        });
+    });
+});

--- a/tests/specs/saveMethodsFolders.spec.js
+++ b/tests/specs/saveMethodsFolders.spec.js
@@ -1,0 +1,58 @@
+import fileExists from '../helpers/fileExists';
+const path = require('path');
+
+describe('wdio-image-comparison-service save methods folder options', () => {
+    const logName = browser.logName;
+    const resolution = '1366x768';
+
+    const testOptions = {
+        returnAllCompareData: true,
+        actualFolder: path.join(process.cwd(), './testActual'),
+        testFolder: './testFolder'
+    };
+
+    beforeEach(() => {
+        browser.url('');
+        browser.pause(500);
+    });
+
+    // Chrome remembers the last postion when the url is loaded again, this will reset it.
+    afterEach(() => browser.execute('window.scrollTo(0, 0);', []));
+
+    describe('saveFullPageScreen method with folder options', () => {
+        it('should set folders using method options', () => {
+            console.log('TEST OPTIONS:', testOptions);
+            const results = browser.saveFullPageScreen('saveFullPageFolderOptions', testOptions);
+            expect(results.path).toMatch(testOptions.actualFolder.replace('./',''));
+        });
+
+        it('should set folders using default options', () => {
+            const results = browser.saveFullPageScreen('saveFullPageDefaultOptions', {});
+            expect(results.path).toMatch('.tmp');
+        });
+    });
+
+    describe('saveScreen method with folder options', () => {
+        it('should set folders using method options', () => {
+            const results = browser.saveScreen('saveScreenFolderOptions', testOptions);
+            expect(results.path).toMatch(testOptions.actualFolder.replace('./',''));
+        });
+
+        it('should set folders using default options', () => {
+            const results = browser.saveScreen('saveScreenDefaultOptions', {});
+            expect(results.path).toMatch('.tmp');
+        });
+    });
+
+    describe('saveElement method with folder options', () => {
+        it('should set folders using method options', () => {
+            const results = browser.saveElement($('.uk-button:nth-child(1)'), 'saveElementFolderOptions', testOptions);
+            expect(results.path).toMatch(testOptions.actualFolder.replace('./',''));
+        });
+
+        it('should set folders using default options', () => {
+            const results = browser.saveElement($('.uk-button:nth-child(1)'), 'saveElementDefaultOptions', {});
+            expect(results.path).toMatch('.tmp');
+        });
+    });
+});


### PR DESCRIPTION
- folder options can be passed as an object to each method and used to
set the folders used to store baseline, actual, and diff images