### PR TITLE
Limit amount of customerCSS calls and add new formatImageName options

### DIFF
--- a/lib/tests/__snapshots__/utils.spec.js.snap
+++ b/lib/tests/__snapshots__/utils.spec.js.snap
@@ -19,65 +19,77 @@ Object {
 exports[`utils getInstanceData should return instance data when all capabilities are provided 1`] = `
 Object {
   "browserName": "chrome",
+  "browserVersion": "75.123",
   "deviceName": "devicename",
   "logName": "logName",
   "name": "",
   "nativeWebScreenshot": false,
   "platformName": "platformname",
+  "platformVersion": "12",
 }
 `;
 
 exports[`utils getInstanceData should return instance data when log name is provided 1`] = `
 Object {
   "browserName": "chrome",
+  "browserVersion": "75.123",
   "deviceName": "",
   "logName": "logName",
   "name": "",
   "nativeWebScreenshot": false,
-  "platformName": "",
+  "platformName": "not-known",
+  "platformVersion": "12",
 }
 `;
 
 exports[`utils getInstanceData should return instance data when the appium log name is provided 1`] = `
 Object {
   "browserName": "chrome",
+  "browserVersion": "75.123",
   "deviceName": "",
   "logName": "appiumLogName",
   "name": "",
   "nativeWebScreenshot": false,
-  "platformName": "",
+  "platformName": "not-known",
+  "platformVersion": "12",
 }
 `;
 
 exports[`utils getInstanceData should return instance data when the minimum of capabilities is provided 1`] = `
 Object {
-  "browserName": "",
+  "browserName": "not-known",
+  "browserVersion": "not-known",
   "deviceName": "",
   "logName": "",
   "name": "",
   "nativeWebScreenshot": false,
-  "platformName": "",
+  "platformName": "not-known",
+  "platformVersion": "not-known",
 }
 `;
 
 exports[`utils getInstanceData should return instance data when the sauce log name is provided 1`] = `
 Object {
   "browserName": "chrome",
+  "browserVersion": "75.123",
   "deviceName": "",
   "logName": "sauceLogName",
   "name": "",
   "nativeWebScreenshot": false,
-  "platformName": "",
+  "platformName": "not-known",
+  "platformVersion": "12",
 }
 `;
 
 exports[`utils getInstanceData should return instance data when wdio-ics option log name is provided 1`] = `
 Object {
   "browserName": "chrome",
+  "browserVersion": "75.123",
   "deviceName": "",
   "logName": "wdio-ics-logName",
   "name": "",
   "nativeWebScreenshot": false,
-  "platformName": "",
+  "platformName": "not-known",
+  "platformVersion": "12",
 }
 `;

--- a/lib/tests/utils.spec.js
+++ b/lib/tests/utils.spec.js
@@ -29,8 +29,20 @@ describe('utils', () => {
     });
 
     describe('getInstanceData', () => {
+        beforeEach(() => {
+            global.browser = {
+                capabilities: {
+                    browserName: 'chrome',
+                    version: '75.123',
+                    platformName: 'osx',
+                    platformVersion: '12',
+                }
+            };
+        })
+
         it('should return instance data when the minimum of capabilities is provided', () => {
             const capabilities = {};
+            global.browser.capabilities = {};
 
             expect(getInstanceData(capabilities)).toMatchSnapshot();
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,7 +32,9 @@ export function getFolders(methodOptions, folders) {
  */
 export function getInstanceData(capabilities) {
     // Substract the needed data from the running instance
-    const browserName = (capabilities.browserName || '').toLowerCase();
+    const currentCapabilities = browser.capabilities;
+    const browserName = (capabilities.browserName || currentCapabilities.browserName || 'not-known').toLowerCase();
+    const browserVersion = (currentCapabilities.version || 'not-known').toLowerCase();
     const logName = capabilities.logName
         || (capabilities[ 'sauce:options' ] ? capabilities[ 'sauce:options' ].logName : null)
         || (capabilities[ 'appium:options' ] ? capabilities[ 'appium:options' ].logName : null)
@@ -41,16 +43,19 @@ export function getInstanceData(capabilities) {
     const name = capabilities.name || '';
 
     // For mobile
-    const platformName = (capabilities.platformName || '').toLowerCase();
+    const platformName = (capabilities.platformName || currentCapabilities.platform || 'not-known').toLowerCase();
+    const platformVersion = (capabilities.platformVersion || currentCapabilities.platformVersion || 'not-known').toLowerCase();
     const deviceName = (capabilities.deviceName || '').toLowerCase();
     const nativeWebScreenshot = !!capabilities.nativeWebScreenshot;
 
     return {
         browserName,
+        browserVersion,
         deviceName,
         logName,
         name,
         nativeWebScreenshot,
         platformName,
+        platformVersion,
     };
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "webdriverio": "^5.9.2"
   },
   "dependencies": {
-    "webdriver-image-comparison": "^0.6.0"
+    "webdriver-image-comparison": "^0.7.0"
   },
   "repository": {
     "type": "git",

--- a/tests/configs/wdio.local.desktop.conf.js
+++ b/tests/configs/wdio.local.desktop.conf.js
@@ -8,12 +8,6 @@ const WdioImageComparisonService = require('../../build/');
 config.capabilities = [
     {
         browserName: 'chrome',
-        specs: [
-            './tests/specs/basics.spec.js',
-            './tests/specs/desktop.spec.js',
-            './tests/specs/checkMethodsFolders.spec.js',
-            './tests/specs/saveMethodsFolders.spec.js',
-        ],
         'goog:chromeOptions': {
             args: [ 'disable-infobars' ],
         },
@@ -21,6 +15,16 @@ config.capabilities = [
             logName: 'chrome-latest',
         },
     },
+];
+
+// ============
+// Capabilities
+// ============
+config.specs= [
+    './tests/specs/basics.spec.js',
+    './tests/specs/desktop.spec.js',
+    './tests/specs/checkMethodsFolders.spec.js',
+    './tests/specs/saveMethodsFolders.spec.js',
 ];
 
 // ===================

--- a/tests/configs/wdio.local.init.conf.js
+++ b/tests/configs/wdio.local.init.conf.js
@@ -3,19 +3,8 @@ const { config } = require('./wdio.local.desktop.conf');
 // ============
 // Capabilities
 // ============
-config.capabilities = [
-    {
-        browserName: 'chrome',
-        specs: [
-            './tests/specs/init.spec.js',
-        ],
-        'goog:chromeOptions': {
-            args: [ 'disable-infobars' ],
-        },
-        'wdio-ics:options': {
-            logName: 'chrome-latest',
-        },
-    },
+config.specs= [
+    './tests/specs/init.spec.js',
 ];
 
 exports.config = config;

--- a/tests/configs/wdio.saucelabs.conf.js
+++ b/tests/configs/wdio.saucelabs.conf.js
@@ -156,11 +156,29 @@ config.capabilities = [
         browserName: 'googlechrome',
         platformName: 'Windows 10',
         browserVersion: 'latest',
-        specs: [
-            basicSpecs,
-            checkMethodFolderSpecs,
-            saveMethodFolderSpecs,
-        ],
+        specs: [ basicSpecs ],
+        'sauce:options': {
+            logName: 'chrome-latest',
+            ...defaultBrowserSauceOptions,
+        },
+        ...chromeOptions,
+    },
+    {
+        browserName: 'googlechrome',
+        platformName: 'Windows 10',
+        browserVersion: 'latest',
+        specs: [ checkMethodFolderSpecs ],
+        'sauce:options': {
+            logName: 'chrome-latest',
+            ...defaultBrowserSauceOptions,
+        },
+        ...chromeOptions,
+    },
+    {
+        browserName: 'googlechrome',
+        platformName: 'Windows 10',
+        browserVersion: 'latest',
+        specs: [ saveMethodFolderSpecs ],
         'sauce:options': {
             logName: 'chrome-latest',
             ...defaultBrowserSauceOptions,

--- a/tests/specs/init.spec.js
+++ b/tests/specs/init.spec.js
@@ -1,7 +1,7 @@
 import { copy } from 'fs-extra';
 import { normalize, join } from 'path'
 
-describe('protractor-image-comparison local development initialization', () => {
+describe('webdriverio image comparison local development initialization', () => {
     const localBaseline = 'localBaseline';
     const checkBaseline = 'checkBaseline';
 


### PR DESCRIPTION
This adds the feature requested in https://github.com/wswebcreation/webdriver-image-comparison/issues/6 including:
- simplify local config
- add extra test instances for sauce chrome
- add new tests

Last but not least it holds a fix to not always do the customerCSS call that caused issues on FireFox

> **NOTE:** This build will probably break because version `0.7.0` of `webdriver-image-comparison` is not yet released. It waits on 2 PR's
> - https://github.com/wswebcreation/webdriver-image-comparison/pull/28
> - https://github.com/wswebcreation/webdriver-image-comparison/pull/29