### PR TITLE
feat: add all types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10554,9 +10554,9 @@
       "dev": true
     },
     "needle": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.2.tgz",
-      "integrity": "sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.3.tgz",
+      "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -14038,9 +14038,9 @@
       }
     },
     "webdriver-image-comparison": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/webdriver-image-comparison/-/webdriver-image-comparison-0.13.1.tgz",
-      "integrity": "sha512-+ny7KxCswS4caMpO/wmIlgYtrfg9UDcc1tFPUVb/pzihmN07VzfaICXuzoK54zrv79TeTU5sqyescZG89p4lPQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/webdriver-image-comparison/-/webdriver-image-comparison-0.13.2.tgz",
+      "integrity": "sha512-LWNDLHlG0OmnfV4fjAG2z99WTdpgpL8KUQIn233beEB7g60mTA8pUSgfm1C0bLOgkDj2/y5z7XGLPttyvFoYJQ==",
       "requires": {
         "canvas": "^2.6.1",
         "chalk": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "webdriverio": "^5.18.7"
   },
   "dependencies": {
-    "webdriver-image-comparison": "0.13.1"
+    "webdriver-image-comparison": "0.13.2"
   },
   "repository": {
     "type": "git",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,43 +1,60 @@
-declare module WebdriverIO {
-    interface Browser {
-        /**
-         * Saves an image of an element
-         */
-        saveElement(element: Element, tag: string, saveElementOptions?: {});
+import {ScreenshotOutput} from "webdriver-image-comparison/build/helpers/afterScreenshot.interfaces";
+import {ImageCompareResult} from "webdriver-image-comparison";
+import {
+    CheckScreenMethodOptions,
+    SaveScreenMethodOptions
+} from "webdriver-image-comparison/build/commands/screen.interfaces";
+import {
+    CheckElementMethodOptions,
+    SaveElementMethodOptions,
+} from "webdriver-image-comparison/build/commands/element.interfaces";
+import {
+    CheckFullPageMethodOptions,
+    SaveFullPageMethodOptions
+} from "webdriver-image-comparison/build/commands/fullPage.interfaces";
 
-        /**
-         * Saves an image of a viewport
-         */
-        saveScreen(tag: string, saveScreenOptions?: {});
+declare global {
+    namespace WebdriverIO {
+        interface Browser {
+            /**
+             * Saves an image of an element
+             */
+            saveElement(element: Element, tag: string, saveElementOptions?: SaveElementMethodOptions): ScreenshotOutput;
 
-        /**
-         * Saves an image of the complete screen
-         */
-        saveFullPageScreen(tag: string, saveFullPageScreenOptions?: {});
+            /**
+             * Saves an image of a viewport
+             */
+            saveScreen(tag: string, saveScreenOptions?: SaveScreenMethodOptions): ScreenshotOutput;
 
-        /**
-         * Saves an image of the complete screen with the tabbable lines and dots
-         */
-        saveTabbablePage(tag: string, saveTabbableOptions?: {});
+            /**
+             * Saves an image of the complete screen
+             */
+            saveFullPageScreen(tag: string, saveFullPageScreenOptions?: SaveFullPageMethodOptions): ScreenshotOutput;
 
-        /**
-         * Compare an image of an element
-         */
-        checkElement(element: Element, tag: string, checkElementOptions?: {});
+            /**
+             * Saves an image of the complete screen with the tabbable lines and dots
+             */
+            saveTabbablePage(tag: string, saveTabbableOptions?: SaveFullPageMethodOptions): ScreenshotOutput;
 
-        /**
-         * Compares an image of a viewport
-         */
-        checkScreen(tag: string, checkScreenOptions?: {});
+            /**
+             * Compare an image of an element
+             */
+            checkElement(element: Element, tag: string, checkElementOptions?: CheckElementMethodOptions): (ImageCompareResult | number);
 
-        /**
-         * Compares an image of the complete screen
-         */
-        checkFullPageScreen(tag: string, checkFullPageOptions?: {});
+            /**
+             * Compares an image of a viewport
+             */
+            checkScreen(tag: string, checkScreenOptions?: CheckScreenMethodOptions): (ImageCompareResult | number);
 
-        /**
-         * Compares an image of the complete screen with the tabbable lines and dots
-         */
-        checkTabbablePage(tag: string, checkTabbableOptions?: {});
+            /**
+             * Compares an image of the complete screen
+             */
+            checkFullPageScreen(tag: string, checkFullPageOptions?: CheckFullPageMethodOptions): (ImageCompareResult | number);
+
+            /**
+             * Compares an image of the complete screen with the tabbable lines and dots
+             */
+            checkTabbablePage(tag: string, checkTabbableOptions?: CheckFullPageMethodOptions): (ImageCompareResult | number);
+        }
     }
 }


### PR DESCRIPTION
This PR is adding all the types, so in favour of https://github.com/wswebcreation/wdio-image-comparison-service/pull/26.

It will now even give warnings on the options, see 
![image](https://user-images.githubusercontent.com/11979740/76139983-142a6c80-6056-11ea-9d3c-38518c49199b.png)
![image](https://user-images.githubusercontent.com/11979740/76139986-24424c00-6056-11ea-99a9-2406aafe7627.png)
![image](https://user-images.githubusercontent.com/11979740/76139990-2c9a8700-6056-11ea-93bd-6a47e0e66d1a.png)

and on the output

![image](https://user-images.githubusercontent.com/11979740/76139996-43d97480-6056-11ea-8d82-b433aa764ae0.png)
![image](https://user-images.githubusercontent.com/11979740/76140010-6075ac80-6056-11ea-86da-2efdba5461b1.png)
