### PR TITLE
Update package.json with version 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "webdriverio": "^6.6.7"
   },
   "dependencies": {
-    "webdriver-image-comparison": "0.15.0"
+    "webdriver-image-comparison": "0.16.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updating the `webdriver-image-comparison` dependency to `0.16.0` to include new `logLevel` option.